### PR TITLE
apply noreply replication patch for high latency network

### DIFF
--- a/src/flared/flared.cc
+++ b/src/flared/flared.cc
@@ -130,6 +130,7 @@ int flared::startup(int argc, char **argv) {
 	log_notice("  mysql_replication_db:   %s", ini_option_object().get_mysql_replication_db().c_str());
 	log_notice("  mysql_replication_table:%s", ini_option_object().get_mysql_replication_table().c_str());
 #endif
+	log_notice("  noreply_window_limit:   %d", ini_option_object().get_noreply_window_limit());
 	log_notice("  net_read_timeout:       %d", ini_option_object().get_net_read_timeout());
 	log_notice("  proxy_concurrency:      %d", ini_option_object().get_proxy_concurrency());
 	log_notice("  reconstruction_interval:%d", ini_option_object().get_reconstruction_interval());
@@ -188,6 +189,7 @@ int flared::startup(int argc, char **argv) {
 	this->_cluster->set_reconstruction_bwlimit(ini_option_object().get_reconstruction_bwlimit());
 	this->_cluster->set_replication_type(ini_option_object().get_replication_type());
 	this->_cluster->set_max_total_thread_queue(ini_option_object().get_max_total_thread_queue());
+	this->_cluster->set_noreply_window_limit(ini_option_object().get_noreply_window_limit());
 	if (this->_cluster->startup_node(ini_option_object().get_index_server_name(),
 									 ini_option_object().get_index_server_port(),
 									 ini_option_object().get_proxy_prior_netmask()) < 0) {
@@ -346,6 +348,9 @@ int flared::reload() {
 
 	// re-setup resource limit (do not care about return value here)
 	this->_set_resource_limit();
+
+	// noreply_window_limit
+	this->_cluster->set_noreply_window_limit(ini_option_object().get_noreply_window_limit());
 
 	log_notice("process successfully reloaded", 0);
 

--- a/src/flared/ini_option.cc
+++ b/src/flared/ini_option.cc
@@ -38,6 +38,7 @@ ini_option::ini_option():
 		_mysql_replication_db(""),
 		_mysql_replication_table(""),
 #endif
+		_noreply_window_limit(default_noreply_window_limit),
 		_net_read_timeout(default_net_read_timeout),
 		_proxy_concurrency(default_proxy_concurrency),
 		_reconstruction_interval(default_reconstruction_interval),
@@ -204,6 +205,10 @@ int ini_option::load() {
 			this->_mysql_replication_table = "flare";
 		}
 #endif
+
+		if (opt_var_map.count("noreply-window-limit")) {
+			this->_noreply_window_limit = opt_var_map["noreply-window-limit"].as<int>();
+		}
 
 		if (opt_var_map.count("net-read-timeout")) {
 			this->_net_read_timeout = opt_var_map["net-read-timeout"].as<int>();
@@ -422,6 +427,12 @@ int ini_option::reload() {
 			log_notice("  max_total_thread_queue: %u -> %u", this->_max_total_thread_queue, opt_var_map["max-total-thread-queue"].as<uint32_t>());
 			this->_max_total_thread_queue = opt_var_map["max-total-thread-queue"].as<uint32_t>();
 		}
+
+		if (opt_var_map.count("noreply-window-limit")) {
+			log_notice("  noreply_window_limit: %d -> %d", this->_noreply_window_limit, opt_var_map["noreply-window-limit"].as<int>());
+			this->_noreply_window_limit = opt_var_map["noreply-window-limit"].as<int>();
+		}
+
 	} catch (int e) {
 		ostringstream ss;
 		ss << option << endl;
@@ -464,12 +475,13 @@ int ini_option::_setup_config_option(program_options::options_description& optio
 		("max-connection",					program_options::value<int>(),			"max concurrent connections to accept (dynamic)")
 		("mutex-slot",							program_options::value<int>(),			"mutex slot size for storage I/O")
 #ifdef ENABLE_MYSQL_REPLICATION
-		("mysql-replication",																						"enabe mysql replication")
+		("mysql-replication",																						"enable mysql replication")
 		("mysql-replication-port",	program_options::value<int>(),			"mysql replication port")
 		("mysql-replication-id",		program_options::value<uint32_t>(),	"mysql replication server id")
 		("mysql-replication-db",		program_options::value<string>(),		"mysql replication database")
 		("mysql-replication-table",	program_options::value<string>(),		"mysql replication table")
 #endif
+		("noreply-window-limit",		program_options::value<int>(),			"noreply window limit")
 		("net-read-timeout",				program_options::value<int>(),			"network read timeout (sec) (dynamic)")
 		("proxy-concurrency",				program_options::value<int>(),			"proxy request concurrency for each node")
 		("reconstruction-interval",	program_options::value<int>(),			"master/slave dump interval in usec (dynamic)")

--- a/src/flared/ini_option.h
+++ b/src/flared/ini_option.h
@@ -42,6 +42,7 @@ private:
 	string			_mysql_replication_db;
 	string			_mysql_replication_table;
 #endif
+	int					_noreply_window_limit;
 	int					_net_read_timeout;
 	int					_proxy_concurrency;
 	int					_reconstruction_interval;
@@ -72,6 +73,7 @@ public:
 	static const int default_mysql_replication_port = 12122;
 	static const int default_mysql_replication_id = 19790217;
 #endif
+	static const int default_noreply_window_limit = 0;						// disabled
 	static const int default_net_read_timeout = 10*60;						// sec
 	static const int default_proxy_concurrency = 2;
 	static const int default_reconstruction_interval = 0;
@@ -113,6 +115,7 @@ public:
 	string get_mysql_replication_db() { return this->_mysql_replication_db; };
 	string get_mysql_replication_table() { return this->_mysql_replication_table; };
 #endif
+	int get_noreply_window_limit() { return this->_noreply_window_limit; };
 	int get_net_read_timeout() { return this->_net_read_timeout; };
 	int get_proxy_concurrency() { return this->_proxy_concurrency; };
 	int get_reconstruction_interval() { return this->_reconstruction_interval; };

--- a/src/lib/cluster.cc
+++ b/src/lib/cluster.cc
@@ -50,6 +50,7 @@ cluster::cluster(thread_pool* tp, string data_dir, string server_name, int serve
 #ifdef ENABLE_MYSQL_REPLICATION
 		_mysql_replication(false),
 #endif
+		_noreply_window_limit(0),
 		_index_server_name(""),
 		_index_server_port(0),
 		_proxy_concurrency(0),

--- a/src/lib/cluster.h
+++ b/src/lib/cluster.h
@@ -169,6 +169,7 @@ protected:
 #ifdef ENABLE_MYSQL_REPLICATION
 	bool									_mysql_replication;
 #endif
+	int										_noreply_window_limit;
 
 	// [node]
 	string								_index_server_name;
@@ -252,6 +253,8 @@ public:
 	int set_mysql_replication(bool mysql_replication) { this->_mysql_replication = mysql_replication; return 0; };
 	bool is_mysql_replication() { return this->_mysql_replication; };
 #endif
+	int set_noreply_window_limit(int noreply_window_limit) { this->_noreply_window_limit = noreply_window_limit; return 0; };
+	int get_noreply_window_limit() { return this->_noreply_window_limit; }
 
 	inline string to_node_key(string server_name, int server_port) {
 		string node_key = server_name + ":" + lexical_cast<string>(server_port);

--- a/src/lib/handler_proxy.h
+++ b/src/lib/handler_proxy.h
@@ -31,6 +31,7 @@ protected:
 	shared_connection		_connection;
 	string							_node_server_name;
 	int									_node_server_port;
+	int									_noreply_count;
 
 public:
 	handler_proxy(shared_thread t, cluster* cl, string node_server_name, int node_server_port);

--- a/src/lib/thread.cc
+++ b/src/lib/thread.cc
@@ -203,9 +203,8 @@ int thread::trigger(thread_handler* th, bool request_delete, bool async) {
 	pthread_mutex_lock(&this->_mutex_trigger);
 	// a fail safe flag in case we send signal before waiting
 	this->_trigger = true;
-	pthread_mutex_unlock(&this->_mutex_trigger);
-
 	pthread_cond_signal(&this->_cond_trigger);
+	pthread_mutex_unlock(&this->_mutex_trigger);
 
 	if (async == false) {
 		pthread_mutex_lock(&this->_mutex_running);


### PR DESCRIPTION
Hi, fujimoto-san.

This is a patch for sending post proxy requests to slaves over high latency network.

We'd like to add --noreply-window-limit option to flared to skip waiting stored replies for some succeeding packets (the number of packets is specified by its argument) and improve request processing speed per thread. This function only takes effect when you specify this option and pass a number above 0 as its argument.

Thanks in advance.

Best regards,
