### PR TITLE
add --key-hash-algorithm option to flarei

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,7 @@ AC_ARG_WITH(tokyocabinet,
 	[  --with-tokyocabinet     tokyocabinet libraries],
 	[CXXFLAGS="${CXXFLAGS} -I${withval}/include -I${withval}/include/tc" LDFLAGS="${LDFLAGS} -L${withval}/lib"])
 AC_CHECK_LIB(tokyocabinet, main, [], [echo "libtokyocabinet not found"; exit 1])
+AC_CHECK_LIB(z, main, [], [echo "zlib not found"; exit 1])
 
 # Checks for additional features
 AC_MSG_CHECKING(if mysql replication is enabled)

--- a/src/flarei/flarei.cc
+++ b/src/flarei/flarei.cc
@@ -118,6 +118,7 @@ int flarei::startup(int argc, char **argv) {
 	log_notice("  partition_modular_virtual: %d", ini_option_object().get_partition_modular_virtual());
 	log_notice("  partition_size:         %d", ini_option_object().get_partition_size());
 	log_notice("  partition_type:         %s", ini_option_object().get_partition_type().c_str());
+	log_notice("  key_hash_algorithm:     %s", ini_option_object().get_key_hash_algorithm().c_str());
 	log_notice("  server_name:            %s", ini_option_object().get_server_name().c_str());
 	log_notice("  server_port:            %d", ini_option_object().get_server_port());
 	log_notice("  server_socket:          %s", ini_option_object().get_server_socket().c_str());
@@ -158,6 +159,13 @@ int flarei::startup(int argc, char **argv) {
 	this->_cluster->set_monitor_interval(ini_option_object().get_monitor_interval());
 	this->_cluster->set_monitor_read_timeout(ini_option_object().get_monitor_read_timeout());
 	this->_cluster->set_partition_size(ini_option_object().get_partition_size());
+
+	storage::hash_algorithm ha;
+	if (storage::hash_algorithm_cast(ini_option_object().get_key_hash_algorithm(), ha) < 0
+			|| ha == storage::hash_algorithm_bitshift) {
+		return -1;
+	}
+	this->_cluster->set_key_hash_algorithm(ha);
 
 	key_resolver::type t;
 	key_resolver::type_cast(ini_option_object().get_partition_type(), t);

--- a/src/flarei/ini_option.cc
+++ b/src/flarei/ini_option.cc
@@ -10,6 +10,7 @@
  *	$Id$
  */
 #include "ini_option.h"
+#include "storage.h"
 
 namespace gree {
 namespace flare {
@@ -179,6 +180,18 @@ int ini_option::load() {
 			this->_partition_type = key_resolver::type_cast(key_resolver::type_modular);
 		}
 
+		if (opt_var_map.count("key-hash-algorithm")) {
+			const string& value = opt_var_map["key-hash-algorithm"].as<string>();
+			storage::hash_algorithm ha;
+			if (storage::hash_algorithm_cast(value, ha) < 0) {
+				cout << "unknown hash algorithm [" << value << "]" << endl;
+				throw -1;
+			}
+			this->_key_hash_algorithm = value;
+		} else {
+			this->_key_hash_algorithm = storage::hash_algorithm_cast(storage::hash_algorithm_simple);
+		}
+
 		if (opt_var_map.count("server-name")) {
 			this->_server_name = opt_var_map["server-name"].as<string>();
 		} else {
@@ -328,6 +341,7 @@ int ini_option::_setup_config_option(program_options::options_description& optio
 		("monitor-read-timeout",		program_options::value<int>(),			"node server monitoring read timeout (millisec) (dynamic)")
 		("partition-modular-hint",	program_options::value<int>(),			"partitioning hint (only for partition-type=modular)")
 		("partition-modular-virtual",	program_options::value<int>(),		"partitioning virtual node size (only for partition-type=modular)")
+		("key-hash-algorithm",			program_options::value<string>(),		"key hash algorithm")
 		("partition-size",					program_options::value<int>(),			"max partition size")
 		("partition-type",					program_options::value<string>(),		"partition type (modular:simple algorithm base)")
 		("server-name",							program_options::value<string>(),		"my server name")

--- a/src/flarei/ini_option.h
+++ b/src/flarei/ini_option.h
@@ -38,6 +38,7 @@ private:
 	int					_partition_modular_virtual;
 	int					_partition_size;
 	string			_partition_type;
+	string			_key_hash_algorithm;
 	string			_server_name;
 	int					_server_port;
 	string			_server_socket;
@@ -79,6 +80,7 @@ public:
 	int get_partition_modular_virtual() { return this->_partition_modular_virtual; };
 	int get_partition_size() { return this->_partition_size; };
 	string get_partition_type() { return this->_partition_type; };
+	string get_key_hash_algorithm() { return this->_key_hash_algorithm; };
 	string get_server_name() { return this->_server_name; };
 	int get_server_port() { return this->_server_port; };
 	string get_server_socket() { return this->_server_socket; };

--- a/src/lib/cluster.cc
+++ b/src/lib/cluster.cc
@@ -36,6 +36,7 @@ namespace flare {
  */
 cluster::cluster(thread_pool* tp, string data_dir, string server_name, int server_port):
 		_thread_pool(tp),
+		_key_hash_algorithm(storage::hash_algorithm_simple),
 		_key_resolver(NULL),
 		_storage(NULL),
 		_data_dir(data_dir),
@@ -228,10 +229,11 @@ int cluster::startup_node(string index_server_name, int index_server_port, uint3
 	// get meta data from index server
 	key_resolver::type key_resolver_type;
 	int partition_size = cluster::default_partition_size;
+	storage::hash_algorithm key_hash_algorithm = storage::hash_algorithm_simple;
 	int key_resolver_modular_hint = 0;
 	int key_resolver_modular_virtual = cluster::default_key_resolver_modular_virtual;
 	op_meta* p_m = _new_ op_meta(c, this);
-	if (p_m->run_client(partition_size, key_resolver_type, key_resolver_modular_hint, key_resolver_modular_virtual) < 0) {
+	if (p_m->run_client(partition_size, key_hash_algorithm, key_resolver_type, key_resolver_modular_hint, key_resolver_modular_virtual) < 0) {
 		log_err("failed to get meta data from index server", 0);
 		_delete_(p_m);
 		return -1;
@@ -240,10 +242,12 @@ int cluster::startup_node(string index_server_name, int index_server_port, uint3
 
 	log_notice("meta data from index server:", 0);
 	log_notice("  partition_size:                 %d", partition_size);
+	log_notice("  key_hash_algorithm:             %s", storage::hash_algorithm_cast(key_hash_algorithm).c_str());
 	log_notice("  key_resolver_type:              %s", key_resolver::type_cast(key_resolver_type).c_str());
 	log_notice("  key_resolver_modular_hint:      %d", key_resolver_modular_hint);
 	log_notice("  key_resolver_modular_virtual:   %d", key_resolver_modular_virtual);
 	this->_partition_size = partition_size;
+	this->_key_hash_algorithm = key_hash_algorithm;
 
 	// startup key resolver
 	if (key_resolver_type == key_resolver::type_modular) {
@@ -1846,7 +1850,7 @@ int cluster::_determine_partition(storage::entry& e, partition& p, bool check_pr
 		if (check_prepare) {
 			partition_size += this->_node_partition_prepare_map.size();
 		}
-		n = this->_key_resolver->resolve(e.get_key_hash_value(), partition_size);
+		n = this->_key_resolver->resolve(e.get_key_hash_value(this->_key_hash_algorithm), partition_size);
 		log_debug("determined partition (key=%s, n=%d)", e.key.c_str(), n);
 
 		if (check_prepare) {

--- a/src/lib/cluster.h
+++ b/src/lib/cluster.h
@@ -141,6 +141,7 @@ public:
 
 protected:
 	thread_pool*					_thread_pool;
+	storage::hash_algorithm _key_hash_algorithm;
 	key_resolver*					_key_resolver;
 	storage*							_storage;
 	type									_type;
@@ -226,6 +227,8 @@ public:
 	vector<node> get_node();
 	vector<node> get_slave_node();
 
+	storage::hash_algorithm get_key_hash_algorithm() { return this->_key_hash_algorithm; };
+	int set_key_hash_algorithm(storage::hash_algorithm key_hash_algorithm) { this->_key_hash_algorithm = key_hash_algorithm; return 0; };
 	key_resolver* get_key_resolver() { return this->_key_resolver; };
 	int set_monitor_threshold(int monitor_threshold);
 	int set_monitor_interval(int monitor_interval);

--- a/src/lib/op_meta.h
+++ b/src/lib/op_meta.h
@@ -28,13 +28,13 @@ public:
 	op_meta(shared_connection c, cluster* cl);
 	virtual ~op_meta();
 
-	virtual int run_client(int& partition_size, key_resolver::type& key_resolver_type, int& key_resolver_modular_hint, int& key_resolver_modular_virtual);
+	virtual int run_client(int& partition_size, storage::hash_algorithm& key_hash_algorithm, key_resolver::type& key_resolver_type, int& key_resolver_modular_hint, int& key_resolver_modular_virtual);
 
 protected:
 	virtual int _parse_server_parameter();
 	virtual int _run_server();
 	virtual int _run_client();
-	virtual int _parse_client_parameter(int& partition_size, key_resolver::type& key_resolver_type, int& key_resolver_modular_hint, int& key_resolver_modular_virtual);
+	virtual int _parse_client_parameter(int& partition_size, storage::hash_algorithm& key_hash_algorithm, key_resolver::type& key_resolver_type, int& key_resolver_modular_hint, int& key_resolver_modular_virtual);
 };
 
 }	// namespace flare

--- a/src/lib/storage.h
+++ b/src/lib/storage.h
@@ -14,6 +14,8 @@
 #include "mm.h"
 #include "util.h"
 
+#include <zlib.h>
+
 using namespace std;
 using namespace boost;
 
@@ -75,6 +77,7 @@ public:
 	enum									hash_algorithm {
 		hash_algorithm_simple = 0,
 		hash_algorithm_bitshift,
+		hash_algorithm_crc32,
 	};
 
 	enum									parse_type {
@@ -126,6 +129,10 @@ public:
 					r = (r << 5) + (r << 2) + r + static_cast<int>(*p);
 					p++;
 				}
+				break;
+			case hash_algorithm_crc32:
+				r = crc32(r, (const Bytef*)p, strlen(p));
+				break;
 			}
 			if (r < 0) {
 				r *= -1;
@@ -397,6 +404,31 @@ public:
 		}
 		return "";
 	};
+
+	static inline int hash_algorithm_cast(const string& s, hash_algorithm& t) {
+		if (s == "simple") {
+			t = hash_algorithm_simple;
+		} else if (s == "bitshift") {
+			t = hash_algorithm_bitshift;
+		} else if (s == "crc32") {
+			t = hash_algorithm_crc32;
+		} else {
+			return -1;
+		}
+		return 0;
+	}
+
+	static inline string hash_algorithm_cast(hash_algorithm t) {
+		switch (t) {
+		case hash_algorithm_simple:
+			return "simple";
+		case hash_algorithm_bitshift:
+			return "bitshift";
+		case hash_algorithm_crc32:
+			return "crc32";
+		}
+		return "";
+	}
 
 protected:
 	virtual int _serialize_header(entry& e, uint8_t* data);


### PR DESCRIPTION
This commit adds --key-hash-algorithm option to flarei daemon to select a hash function for keys.
If the user specifies "simple" or "crc32" as its value, flared selects the specified hash function for data distribution.
