### PR TITLE
Add pthread_mutex_init, pthread_rwlock_init, pthread_cond_init error handlings

### DIFF
--- a/src/flarefs/fuse_fs.cc
+++ b/src/flarefs/fuse_fs.cc
@@ -8,6 +8,7 @@
  *	$Id$
  */
 #include "fuse_fs.h"
+#include "abort.h"
 
 namespace gree {
 namespace flare {
@@ -25,7 +26,7 @@ fuse_fs::fuse_fs(string node_server_name, int node_server_port, int chunk_size, 
 		_client_pool_size(client_pool_size),
 		_node_server_name(node_server_name),
 		_node_server_port(node_server_port) {
-	pthread_mutex_init(&this->_mutex_pool, NULL);
+	ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_pool, NULL), 0);
 }
 
 /**

--- a/src/lib/abort.h
+++ b/src/lib/abort.h
@@ -1,0 +1,20 @@
+/**
+ *	abort.h
+ *
+ *	@author	Yuya YAGUCHI <yuya.yaguchi@gree.net>
+ *
+ *	$Id$
+ */
+
+#ifndef ABORT_H
+#define ABORT_H
+
+#include <stdlib.h>
+
+#define ABORT_IF_FAILURE(actual, expect) \
+	if (actual != expect) { \
+		abort(); \
+	}
+
+#endif// ABORT_H
+// vim: foldmethod=marker tabstop=2 shiftwidth=2 autoindent

--- a/src/lib/cluster.cc
+++ b/src/lib/cluster.cc
@@ -26,6 +26,7 @@
 #include "queue_proxy_write.h"
 #include "queue_update_monitor_option.h"
 #include "coordinator.h"
+#include "abort.h"
 
 #include <functional>
 #include <boost/bind.hpp>
@@ -66,11 +67,11 @@ cluster::cluster(thread_pool* tp, string server_name, int server_port):
 		_proxy_prior_netmask(0), 
 		_max_total_thread_queue(0) {
 	this->_node_key = this->to_node_key(server_name, server_port);
-	pthread_mutex_init(&this->_mutex_serialization, NULL);
-	pthread_mutex_init(&this->_mutex_master_reconstruction, NULL);
-	pthread_mutex_init(&this->_mutex_node_map_version, NULL);
-	pthread_rwlock_init(&this->_mutex_node_map, NULL);
-	pthread_rwlock_init(&this->_mutex_node_partition_map, NULL);
+	ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_serialization, NULL), 0);
+	ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_master_reconstruction, NULL), 0);
+	ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_node_map_version, NULL), 0);
+	ABORT_IF_FAILURE(pthread_rwlock_init(&this->_mutex_node_map, NULL), 0);
+	ABORT_IF_FAILURE(pthread_rwlock_init(&this->_mutex_node_partition_map, NULL), 0);
 }
 
 /**

--- a/src/lib/file_coordinator.cc
+++ b/src/lib/file_coordinator.cc
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <fstream>
 
+#include "abort.h"
 #include "util.h"
 #include "file_coordinator.h"
 
@@ -28,7 +29,7 @@ namespace flare {
  */
 file_coordinator::file_coordinator(const string& coordinator_uri)
 	: _uri(coordinator_uri) {
-	pthread_mutex_init(&this->_mutex_file_manipulation, NULL);
+	ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_file_manipulation, NULL), 0);
 	if (this->get_scheme() != "file") {
 		log_warning("invalid scheme [%s]", this->get_scheme().c_str());
 	}

--- a/src/lib/storage.cc
+++ b/src/lib/storage.cc
@@ -11,6 +11,7 @@
 #include "storage.h"
 #include "binary_request_header.h"
 #include "binary_response_header.h"
+#include "abort.h"
 
 namespace gree {
 namespace flare {
@@ -30,10 +31,10 @@ storage::storage(string data_dir, int mutex_slot_size, int header_cache_size):
 	this->_mutex_slot = new pthread_rwlock_t[mutex_slot_size];
 	int i;
 	for (i = 0; i < this->_mutex_slot_size; i++) {
-		pthread_rwlock_init(&this->_mutex_slot[i], NULL);
+		ABORT_IF_FAILURE(pthread_rwlock_init(&this->_mutex_slot[i], NULL), 0);
 	}
-	pthread_mutex_init(&_mutex_iter_lock, NULL);
-	pthread_rwlock_init(&this->_mutex_header_cache_map, NULL);
+	ABORT_IF_FAILURE(pthread_mutex_init(&_mutex_iter_lock, NULL), 0);
+	ABORT_IF_FAILURE(pthread_rwlock_init(&this->_mutex_header_cache_map, NULL), 0);
 
 	this->_header_cache_map = tcmapnew();
 }

--- a/src/lib/thread.cc
+++ b/src/lib/thread.cc
@@ -11,6 +11,7 @@
 #include "thread.h"
 #include "thread_pool.h"
 #include "thread_handler.h"
+#include "abort.h"
 
 namespace gree {
 namespace flare {
@@ -86,15 +87,15 @@ thread::thread(thread_pool* t):
 	this->_info.timestamp = 0;
 	this->_info.state = "";
 	this->_info.info = "";
-	pthread_mutex_init(&this->_mutex_trigger, NULL);
-	pthread_cond_init(&this->_cond_trigger, NULL);
-	pthread_mutex_init(&this->_mutex_shutdown, NULL);
-	pthread_cond_init(&this->_cond_shutdown, NULL);
-	pthread_mutex_init(&this->_mutex_queue, NULL);
-	pthread_cond_init(&this->_cond_queue, NULL);
-	pthread_mutex_init(&this->_mutex_running, NULL);
-	pthread_cond_init(&this->_cond_running, NULL);
-	pthread_rwlock_init(&this->_mutex_info, NULL);
+	ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_trigger, NULL), 0);
+	ABORT_IF_FAILURE(pthread_cond_init(&this->_cond_trigger, NULL), 0);
+	ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_shutdown, NULL), 0);
+	ABORT_IF_FAILURE(pthread_cond_init(&this->_cond_shutdown, NULL), 0);
+	ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_queue, NULL), 0);
+	ABORT_IF_FAILURE(pthread_cond_init(&this->_cond_queue, NULL), 0);
+	ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_running, NULL), 0);
+	ABORT_IF_FAILURE(pthread_cond_init(&this->_cond_running, NULL), 0);
+	ABORT_IF_FAILURE(pthread_rwlock_init(&this->_mutex_info, NULL), 0);
 }
 
 /**

--- a/src/lib/thread_pool.cc
+++ b/src/lib/thread_pool.cc
@@ -8,6 +8,7 @@
  *	$Id$
  */
 #include "thread_pool.h"
+#include "abort.h"
 
 namespace gree {
 namespace flare {
@@ -22,8 +23,8 @@ thread_pool::thread_pool(thread_pool::pool::size_type max_pool_size, int stack_s
 		_stack_size(stack_size) {
 	this->_global_map.clear();
 
-	pthread_rwlock_init(&this->_mutex_global_map, NULL);
-	pthread_rwlock_init(&this->_mutex_pool, NULL);
+	ABORT_IF_FAILURE(pthread_rwlock_init(&this->_mutex_global_map, NULL), 0);
+	ABORT_IF_FAILURE(pthread_rwlock_init(&this->_mutex_pool, NULL), 0);
 }
 
 /**

--- a/src/lib/thread_queue.cc
+++ b/src/lib/thread_queue.cc
@@ -8,6 +8,7 @@
  *	$Id$
  */
 #include "thread_queue.h"
+#include "abort.h"
 #include "app.h"
 
 namespace gree {
@@ -79,8 +80,8 @@ int thread_queue::sync() {
 int thread_queue::sync_ref() {
 	if (this->_sync == false) {
 		this->_sync = true;
-		pthread_mutex_init(&this->_mutex_sync, NULL);
-		pthread_cond_init(&this->_cond_sync, NULL);
+		ABORT_IF_FAILURE(pthread_mutex_init(&this->_mutex_sync, NULL), 0);
+		ABORT_IF_FAILURE(pthread_cond_init(&this->_cond_sync, NULL), 0);
 	}
 
 	pthread_mutex_lock(&this->_mutex_sync);

--- a/src/lib/zookeeper_coordinator.cc
+++ b/src/lib/zookeeper_coordinator.cc
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <boost/format.hpp>
 
+#include "abort.h"
 #include "util.h"
 #include "logger.h"
 #include "zookeeper_coordinator.h"
@@ -38,9 +39,9 @@ zookeeper_coordinator::zookeeper_coordinator(const string& coordinator_uri, cons
 		_sync_nodemap(false),
 		_retry(default_retry_count) {
 
-	pthread_mutex_init(&(this->_mutex_sync_nodemap), NULL);
-	pthread_cond_init(&(this->_cond_sync_nodemap), NULL);
-	pthread_mutex_init(&(this->_mutex_operation_pool), NULL);
+	ABORT_IF_FAILURE(pthread_mutex_init(&(this->_mutex_sync_nodemap), NULL), 0);
+	ABORT_IF_FAILURE(pthread_cond_init(&(this->_cond_sync_nodemap), NULL), 0);
+	ABORT_IF_FAILURE(pthread_mutex_init(&(this->_mutex_operation_pool), NULL), 0);
 
 	/* check the scheme part of identifier */
 	if (this->get_scheme() != "zookeeper") {

--- a/src/lib/zookeeper_lock.cc
+++ b/src/lib/zookeeper_lock.cc
@@ -12,6 +12,7 @@
 #include <boost/format.hpp>
 #include <uuid/uuid.h>
 
+#include "abort.h"
 #include "util.h"
 #include "zookeeper_lock.h"
 
@@ -50,12 +51,12 @@ zookeeper_lock::zookeeper_lock(const string& connstring, const string& path, str
 		_is_owner(false) {
 	this->_wait_ts.tv_sec = 0;
 	this->_wait_ts.tv_nsec = (.5)*1000000;
-	pthread_mutex_init(&(this->_mutex_lock), NULL);
-	pthread_mutex_init(&(this->_mutex_ownership), NULL);
-	pthread_cond_init(&(this->_cond_ownership), NULL);
+	ABORT_IF_FAILURE(pthread_mutex_init(&(this->_mutex_lock), NULL), 0);
+	ABORT_IF_FAILURE(pthread_mutex_init(&(this->_mutex_ownership), NULL), 0);
+	ABORT_IF_FAILURE(pthread_cond_init(&(this->_cond_ownership), NULL), 0);
 	this->_session_state = session_state_inactive;
-	pthread_mutex_init(&(this->_mutex_session_state), NULL);
-	pthread_cond_init(&(this->_cond_session_state), NULL);
+	ABORT_IF_FAILURE(pthread_mutex_init(&(this->_mutex_session_state), NULL), 0);
+	ABORT_IF_FAILURE(pthread_cond_init(&(this->_cond_session_state), NULL), 0);
 	this->_zh = zookeeper_init(connstring.c_str(), zookeeper_lock::_global_watcher_fn,
 														 10000, 0, reinterpret_cast<void *>(this), 0);
 	this->_reset_lock();


### PR DESCRIPTION
pthread_*_init() is written in constructors.
So if this function return error value, we have only two ways to handle this error.
First way is throw exception. But this way we need many changes.
Second way is call abort() to cause program termination.

pthread_*_init failure is quite uncommon case in many environments. And if error has occur, fix to normal is difficult.

So we choose second case.
