### PR TITLE
Introduce a rwlock for write operations for dump

### DIFF
--- a/src/lib/storage.cc
+++ b/src/lib/storage.cc
@@ -37,6 +37,7 @@ storage::storage(string data_dir, int mutex_slot_size, int header_cache_size):
 	}
 	pthread_mutex_init(&_mutex_iter_lock, NULL);
 	pthread_rwlock_init(&this->_mutex_header_cache_map, NULL);
+	pthread_rwlock_init(&this->_mutex_wholelock, NULL);
 
 	this->_header_cache_map = tcmapnew();
 }
@@ -52,6 +53,7 @@ storage::~storage() {
 	this->_mutex_slot = NULL;
 	pthread_mutex_destroy(&_mutex_iter_lock);
 	pthread_rwlock_destroy(&_mutex_header_cache_map);
+	pthread_rwlock_destroy(&_mutex_wholelock);
 
 	if (this->_header_cache_map) {
 		tcmapdel(this->_header_cache_map);

--- a/src/lib/storage.h
+++ b/src/lib/storage.h
@@ -188,7 +188,7 @@ protected:
 	TCMAP*								_header_cache_map;
 	pthread_rwlock_t			_mutex_header_cache_map;
 	storage_listener*			_listener;
-
+	pthread_rwlock_t			_mutex_wholelock;
 
 public:
 	storage(string data_dir, int mutex_slot_size, int header_cache_size);

--- a/src/lib/storage_tcb.cc
+++ b/src/lib/storage_tcb.cc
@@ -114,6 +114,7 @@ int storage_tcb::set(entry& e, result& r, int b) {
 	uint8_t* p = NULL;
 	try {
 		if ((b & behavior_skip_lock) == 0) {
+			pthread_rwlock_rdlock(&this->_mutex_wholelock);
 			pthread_rwlock_wrlock(&this->_mutex_slot[mutex_index]);
 		}
 
@@ -276,12 +277,14 @@ int storage_tcb::set(entry& e, result& r, int b) {
 		delete[] p;
 		if ((b & behavior_skip_lock) == 0) {
 			pthread_rwlock_unlock(&this->_mutex_slot[mutex_index]);
+			pthread_rwlock_unlock(&this->_mutex_wholelock);
 		}
 		return error;
 	}
 	delete[] p;
 	if ((b & behavior_skip_lock) == 0) {
 		pthread_rwlock_unlock(&this->_mutex_slot[mutex_index]);
+		pthread_rwlock_unlock(&this->_mutex_wholelock);
 	}
 
 	return 0;
@@ -302,6 +305,7 @@ int storage_tcb::incr(entry& e, uint64_t value, result& r, bool increment, int b
 	bool expired = false;
 	try {
 		if ((b & behavior_skip_lock) == 0) {
+			pthread_rwlock_rdlock(&this->_mutex_wholelock);
 			pthread_rwlock_wrlock(&this->_mutex_slot[mutex_index]);
 		}
 
@@ -405,12 +409,14 @@ int storage_tcb::incr(entry& e, uint64_t value, result& r, bool increment, int b
 		}
 		if ((b & behavior_skip_lock) == 0) {
 			pthread_rwlock_unlock(&this->_mutex_slot[mutex_index]);
+			pthread_rwlock_unlock(&this->_mutex_wholelock);
 		}
 		return error;
 	}
 	delete[] p;
 	if ((b & behavior_skip_lock) == 0) {
 		pthread_rwlock_unlock(&this->_mutex_slot[mutex_index]);
+		pthread_rwlock_unlock(&this->_mutex_wholelock);
 	}
 
 	return 0;
@@ -495,6 +501,7 @@ int storage_tcb::remove(entry& e, result& r, int b) {
 
 	try {
 		if ((b & behavior_skip_lock) == 0) {
+			pthread_rwlock_rdlock(&this->_mutex_wholelock);
 			pthread_rwlock_wrlock(&this->_mutex_slot[mutex_index]);
 		}
 
@@ -540,11 +547,13 @@ int storage_tcb::remove(entry& e, result& r, int b) {
 	} catch (int error) {
 		if ((b & behavior_skip_lock) == 0) {
 			pthread_rwlock_unlock(&this->_mutex_slot[mutex_index]);
+			pthread_rwlock_unlock(&this->_mutex_wholelock);
 		}
 		return error;
 	}
 	if ((b & behavior_skip_lock) == 0) {
 		pthread_rwlock_unlock(&this->_mutex_slot[mutex_index]);
+		pthread_rwlock_unlock(&this->_mutex_wholelock);
 	}
 
 	return 0;
@@ -554,6 +563,7 @@ int storage_tcb::truncate(int b) {
 	log_info("truncating all data", 0);
 
 	if ((b & behavior_skip_lock) == 0) {
+		pthread_rwlock_wrlock(&this->_mutex_wholelock);
 		this->_mutex_slot_wrlock_all();
 	}
 
@@ -568,6 +578,7 @@ int storage_tcb::truncate(int b) {
 
 	if ((b & behavior_skip_lock) == 0) {
 		this->_mutex_slot_unlock_all();
+		pthread_rwlock_unlock(&this->_mutex_wholelock);
 	}
 
 	return r;
@@ -600,7 +611,7 @@ storage::iteration storage_tcb::iter_next(string& key) {
 	int len = 0;
 	char* p = NULL;
 	
-	this->_mutex_slot_rdlock_all();
+	pthread_rwlock_wrlock(&this->_mutex_wholelock);
 	{
 		if (this->_iter_first) {
 			tcbdbcurfirst(this->_cursor);
@@ -610,7 +621,7 @@ storage::iteration storage_tcb::iter_next(string& key) {
 		}
 		p = static_cast<char*>(tcbdbcurkey(this->_cursor, &len));
 	}
-	this->_mutex_slot_unlock_all();
+	pthread_rwlock_unlock(&this->_mutex_wholelock);
 
 	if (p == NULL) {
 		int ecode = tcbdbecode(this->_db);


### PR DESCRIPTION
Introduce a rwlock for write operations to avoid taking lots of read locks during dump operation
