### PR TITLE
Add node_map_version information to on_stats

### DIFF
--- a/src/flared/op_stats_node.cc
+++ b/src/flared/op_stats_node.cc
@@ -93,7 +93,9 @@ int op_stats_node::_run_server() {
 		this->_send_stats_threads_queue();
 		break;
 	default:
-		this->_send_stats(singleton<flared>::instance().get_thread_pool(), singleton<flared>::instance().get_storage());
+		this->_send_stats(singleton<flared>::instance().get_thread_pool(),
+				singleton<flared>::instance().get_storage(),
+				singleton<flared>::instance().get_cluster());
 		break;
 	}
 	this->_send_result(result_end);

--- a/src/flarei/op_stats_index.cc
+++ b/src/flarei/op_stats_index.cc
@@ -86,7 +86,9 @@ int op_stats_index::_run_server() {
 		this->_send_stats_threads_queue();
 		break;
 	default:
-		this->_send_stats(singleton<flarei>::instance().get_thread_pool(), NULL);
+		this->_send_stats(singleton<flarei>::instance().get_thread_pool(),
+				NULL,
+				singleton<flarei>::instance().get_cluster());
 		break;
 	}
 	this->_send_result(result_end);

--- a/src/lib/op_stats.cc
+++ b/src/lib/op_stats.cc
@@ -118,7 +118,7 @@ int op_stats::_run_server() {
 	return 0;
 }
 
-int op_stats::_send_stats(thread_pool* tp, storage* st) {
+int op_stats::_send_stats(thread_pool* tp, storage* st, cluster* cl) {
 	rusage usage = stats_object->get_rusage();
 	char usage_user[BUFSIZ];
 	char usage_system[BUFSIZ];
@@ -159,6 +159,7 @@ int op_stats::_send_stats(thread_pool* tp, storage* st) {
 	_send_stat("limit_maxbytes" 			, stats_object->get_limit_maxbytes());
 	_send_stat("threads"							, stats_object->get_threads(tp));
 	_send_stat("pool_threads" 				, stats_object->get_pool_threads(tp));
+	_send_stat("node_map_version"		, cl->get_node_map_version());
 
 	return 0;
 }

--- a/src/lib/op_stats.h
+++ b/src/lib/op_stats.h
@@ -69,7 +69,7 @@ protected:
 	virtual int _parse_binary_request(const binary_request_header&, const char* body);
 	virtual int _run_server();
 
-	virtual int _send_stats(thread_pool* tp, storage* st);
+	virtual int _send_stats(thread_pool* tp, storage* st, cluster* cl);
 	virtual int _send_stats_items();
 	virtual int _send_stats_slabs();
 	virtual int _send_stats_sizes();


### PR DESCRIPTION
Node_map_version is important information to recover from index server failure.
This makes possible to get node_map_version using STATS command.