### PR TITLE
Fix to pass memory-tests

### DIFF
--- a/test/flare.supp
+++ b/test/flare.supp
@@ -4,23 +4,13 @@
    fun:malloc
    fun:g_malloc
    fun:g_slice_alloc
-   fun:g_list_append
-   obj:/usr/lib/cutter/module/ui/console.so
-   obj:/usr/lib/cutter/module/ui/console.so
-   fun:g_closure_invoke
+   fun:g_slice_alloc0
+   fun:g_type_create_instance
    obj:/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.*
-   fun:g_signal_emit_valist
-   fun:g_signal_emit_by_name
-   fun:cut_run_context_emit_complete_run
-   fun:cut_runner_run
-}
-{
-   Ignore leaks due to incorrect thread pool usage
-   Memcheck:Leak
-   fun:_Znwm
-   fun:_ZN4gree5flare11thread_pool14_create_threadEv
-   fun:_ZN4gree5flare11thread_pool3getEi
-   fun:_ZN16test_thread_pool*
-   ...
-   fun:cut_runner_run
+   fun:g_object_new_valist
+   fun:cut_module_instantiate
+   fun:cut_module_factory_new
+   obj:/usr/lib/libcutter.so.*
+   fun:cut_factory_builder_build
+   fun:cut_contractor_build_factories
 }

--- a/test/lib/test_handler_cluster_replication.cc
+++ b/test/lib/test_handler_cluster_replication.cc
@@ -175,6 +175,8 @@ namespace test_handler_cluster_replication {
 			usleep(100 * 1000); // waiting for queue proceeded
 			cut_assert_equal_boolean(true, queues[i]->is_success());
 			cut_assert_equal_int(op::result_stored, queues[i]->get_result());
+			delete[] p;
+			delete[] q;
 		}
 
 		cut_assert_equal_boolean(true, t->is_running());


### PR DESCRIPTION
* Fix 'flare.supp' to pass in Ubuntu trusty
    + Add a suppression to ignore memory leaks because of cutter
    + Delete suppressions that no longer necessary
* Add deallocate lines test_run_success_async

```
5153 test(s), 168767 assertion(s), 0 failure(s), 0 error(s), 0 pending(s), 0 omission(s), 3 notification(s)
100% passed
valgrind has reported 0 bytes definitely lost.
```