### PR TITLE
connection_tcp: Clear buffers when connection closed.

### DIFF
--- a/src/lib/connection_tcp.cc
+++ b/src/lib/connection_tcp.cc
@@ -625,6 +625,8 @@ int connection_tcp::close() {
 	} else {
 		log_info("close() called but socket seems to be already closed [%d]", this->_sock);
 	}
+	this->_clear_read_buf();
+	this->_clear_write_buf();
 	return 0;
 }
 
@@ -726,6 +728,16 @@ int connection_tcp::_add_write_buf(const char* p, int len) {
 	return this->_write_buf_len;
 }
 // }}}
+
+int connection_tcp::_clear_write_buf() {
+	log_debug("clearing internal read buffer (read_buf_len=%d)", this->_read_buf_len);
+	delete[] this->_write_buf;
+	this->_write_buf = NULL;
+	this->_write_buf_len = 0;
+	this->_write_buf_chunk_size = 0;
+
+	return 0;
+}
 
 }	// namespace flare
 }	// namespace gree

--- a/src/lib/connection_tcp.h
+++ b/src/lib/connection_tcp.h
@@ -137,6 +137,7 @@ private:
 	int _add_read_buf(char* p, int len);
 	int _clear_read_buf();
 	int _add_write_buf(const char* p, int len);
+	int _clear_write_buf();
 };
 
 }	// namespace flare


### PR DESCRIPTION
This patch fixes issue when connection closed and re-opened.

Connections are sometime closed by network problems.
And connection classes are reused with re-open.
so, `connection_tcp::close()` method should clear buffers to avoid send/recv old garbage data.