### PR TITLE
Fix proxy-write of forward-mode for cluster-replication

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1634851050,
-        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -32,6 +32,21 @@
     },
     "flake-utils_3": {
       "locked": {
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
@@ -45,9 +60,54 @@
         "type": "github"
       }
     },
-    "flare-tests": {
+    "flare": {
       "inputs": {
         "flake-utils": "flake-utils_2",
+        "flare-tests": "flare-tests_2",
+        "flare-tools": "flare-tools",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1646028281,
+        "narHash": "sha256-QuxcHyD3x+pSXnsGQiuzsr83q/9FRvsRY7c2Jk+2hAw=",
+        "owner": "gree",
+        "repo": "flare",
+        "rev": "9b1e2a9a987113f1c0c7873fe591fbe7b673f7e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gree",
+        "repo": "flare",
+        "type": "github"
+      }
+    },
+    "flare-tests": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "flare": "flare",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646044580,
+        "narHash": "sha256-+Dy4NiVm9KSrAzztgYYLziybAGyhEWmoSp/KWw/y5oo=",
+        "owner": "gree",
+        "repo": "flare-tests",
+        "rev": "ea3f93f3440ee46bdb9a31398947b8e9e88badb9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gree",
+        "repo": "flare-tests",
+        "type": "github"
+      }
+    },
+    "flare-tests_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
@@ -66,8 +126,31 @@
     },
     "flare-tools": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1645783248,
+        "narHash": "sha256-PXvAsTxffTiO79vri1YKMplvHJRFaCv25PF74iYcv08=",
+        "owner": "gree",
+        "repo": "flare-tools",
+        "rev": "2c030d70dbbf239b2cca1948411c8e6df278b8e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gree",
+        "repo": "flare-tools",
+        "type": "github"
+      }
+    },
+    "flare-tools_2": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1645783248,
@@ -127,12 +210,28 @@
         "type": "github"
       }
     },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1635261841,
+        "narHash": "sha256-TsPBFEIarRkpDoqIX0cqi4PxYq2w1oVygElpPokIDaU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2558d8e64f3816ec4291555fc8dc2212bd21f0a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2558d8e64f3816ec4291555fc8dc2212bd21f0a8",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "flare-tests": "flare-tests",
-        "flare-tools": "flare-tools",
-        "nixpkgs": "nixpkgs_3"
+        "flare-tools": "flare-tools_2",
+        "nixpkgs": "nixpkgs_4"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -6,10 +6,14 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs";
+    nixpkgs.url = "github:nixos/nixpkgs?rev=2558d8e64f3816ec4291555fc8dc2212bd21f0a8";
     flake-utils.url = "github:numtide/flake-utils";
     flare-tests.url = "github:gree/flare-tests";
+    flare-tests.inputs.nixpkgs.follows = "nixpkgs";
+    flare-tests.inputs.flake-utils.follows = "flake-utils";
     flare-tools.url = "github:gree/flare-tools";
+    flare-tools.inputs.nixpkgs.follows = "nixpkgs";
+    flare-tools.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = { self

--- a/src/lib/cluster.cc
+++ b/src/lib/cluster.cc
@@ -1368,8 +1368,11 @@ cluster::proxy_request cluster::pre_proxy_write(op_proxy_write* op, shared_queue
 	for (vector<shared_proxy_event_listener>::iterator it = this->_fixed_proxy_event_listeners.begin();
 			it != this->_fixed_proxy_event_listeners.end(); it++) {
 		shared_queue_proxy_write q_proxy_result;
-		proxy_request r = (*it)->on_pre_proxy_write(op, q_proxy_result, generic_value);
-		if (r == proxy_request_continue) {
+		proxy_request r = (*it)->on_pre_proxy_write(op, e, q_proxy_result, generic_value);
+		if (r == proxy_request_complete) {
+			q_result = q_proxy_result;
+			return proxy_request_complete;
+		} else if (r == proxy_request_continue) {
 			continue;
 		} else {
 			return r;

--- a/src/lib/cluster_replication.h
+++ b/src/lib/cluster_replication.h
@@ -76,7 +76,7 @@ public:
 	int get_concurrency() { return this->_concurrency; };
 
 	virtual cluster::proxy_request on_pre_proxy_read(op_proxy_read* op, storage::entry& e, void* parameter, shared_queue_proxy_read& q_result);
-	virtual cluster::proxy_request on_pre_proxy_write(op_proxy_write* op, shared_queue_proxy_write& q_result, uint64_t generic_value);
+	virtual cluster::proxy_request on_pre_proxy_write(op_proxy_write* op, storage::entry& e, shared_queue_proxy_write& q_result, uint64_t generic_value);
 	virtual cluster::proxy_request on_post_proxy_write(op_proxy_write* op, cluster::node node);
 
 	static inline int mode_cast(string s, mode& m) {

--- a/src/lib/proxy_event_listener.h
+++ b/src/lib/proxy_event_listener.h
@@ -41,7 +41,7 @@ public:
 	virtual ~proxy_event_listener() { }
 
 	virtual cluster::proxy_request on_pre_proxy_read(op_proxy_read* op, storage::entry& e, void* parameter, shared_queue_proxy_read& q_result) = 0;
-	virtual cluster::proxy_request on_pre_proxy_write(op_proxy_write* op, shared_queue_proxy_write& q_result, uint64_t generic_value) = 0;
+	virtual cluster::proxy_request on_pre_proxy_write(op_proxy_write* op, storage::entry& e, shared_queue_proxy_write& q_result, uint64_t generic_value) = 0;
 	virtual cluster::proxy_request on_post_proxy_write(op_proxy_write* op, cluster::node node) = 0;
 };
 


### PR DESCRIPTION
クラスタ間レプリケーションのforwardモードでwrite系がforwardされない問題を修正するPRです。
このコードがないとcasやdeleteでの問題が顕著にでます。
