### PR TITLE
Add base64_map to signed

### DIFF
--- a/src/lib/util.cc
+++ b/src/lib/util.cc
@@ -225,7 +225,7 @@ string util::base64_encode(const char* src, size_t src_size) {
 }
 
 char* util::base64_decode(string src, size_t& dst_size) {
-	static const char base64_map[] = {
+	static const signed char base64_map[] = {
 		-2, -2, -2, -2, -2, -2, -2, -2, -2, -1, -1, -2, -2, -1, -2, -2,
 		-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
 		-1, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, 62, -2, -2, -2, 63,


### PR DESCRIPTION
jammyでのビルドで、次のエラーがでるので修正します。
> util.cc:245:9: error: narrowing conversion of '-2' from 'int' to 'char' [-Wnarrowing]